### PR TITLE
useMediaControls: Add `volumechange` event listener

### DIFF
--- a/packages/core/useMediaControls/index.ts
+++ b/packages/core/useMediaControls/index.ts
@@ -479,6 +479,10 @@ export function useMediaControls(target: MaybeRef<HTMLMediaElement | null | unde
   useEventListener(target, 'play', () => ignorePlayingUpdates(() => playing.value = true))
   useEventListener(target, 'enterpictureinpicture', () => isPictureInPicture.value = true)
   useEventListener(target, 'leavepictureinpicture', () => isPictureInPicture.value = false)
+  useEventListener(target, 'volumechange', () => {
+    options.muted.value = (unref(target))!.muted
+    volume.value = (unref(target))!.volume
+  })
 
   /**
    * The following listeners need to listen to a nested


### PR DESCRIPTION
If you change the volume or muted values by native controls (or in devtools) it does not effect reactive variables. [Here is a demonstration](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcbmltcG9ydCB7IHVzZU1lZGlhQ29udHJvbHMgfSBmcm9tICdAdnVldXNlL2NvcmUnXG4gIFxuY29uc3Qgb3JpZ2luU291cmNlID0gJ2h0dHBzOi8vaW50ZXJhY3RpdmUtZXhhbXBsZXMubWRuLm1vemlsbGEubmV0L21lZGlhL2NjMC12aWRlb3MvZmxvd2VyLndlYm0nXG5jb25zdCBzcmMgPSByZWYob3JpZ2luU291cmNlKVxuXG5jb25zdCBtdXRlZCA9IHJlZihmYWxzZSlcbmNvbnN0IHZpZGVvRWxlbWVudCA9IHJlZigpXG5jb25zdCB7cGxheWluZywgdm9sdW1lfSA9IHVzZU1lZGlhQ29udHJvbHModmlkZW9FbGVtZW50LCB7XG4gIGF1dG9wbGF5OiBmYWxzZSwgLy8gPC0tXG4gIGNvbnRyb2xzOiB0cnVlLCBcbiAgcHJlbG9hZDogJ21ldGFkYXRhJyxcbiAgc3JjLFxuICBtdXRlZFxufSlcblxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGRpdiBzdHlsZT1cImRpc3BsYXk6IGdyaWQ7IHBsYWNlLWNvbnRlbnQ6IGNlbnRlcjsgcGxhY2UtaXRlbXM6IGNlbnRlcjsgaGVpZ2h0OiAxMDAlOyBnYXA6IDFyZW07IHVzZXItc2VsZWN0OiBub25lO1wiPlxuICAgIDx2aWRlbyAgcmVmPVwidmlkZW9FbGVtZW50XCI+PC92aWRlbz5cbiAgICBcbiAgICB2b2x1bWU6IHt7dm9sdW1lfX1cbiAgICBtdXRlZDoge3ttdXRlZH19XG4gIDwvZGl2PlxuPC90ZW1wbGF0ZT5cbiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcblx0XHRcIkB2dWV1c2UvY29yZVwiOiBcImh0dHBzOi8vdW5wa2cuY29tL0B2dWV1c2UvY29yZS9kaXN0L2luZGV4LmVzbS5qc1wiLFxuICAgIFwiQHZ1ZXVzZS9zaGFyZWRcIjogXCJodHRwczovL3VucGtnLmNvbS9AdnVldXNlL3NoYXJlZC9kaXN0L2luZGV4LmVzbS5qc1wiLFxuICAgIFwidnVlLWRlbWlcIjogXCJodHRwczovL3VucGtnLmNvbS92dWUtZGVtaS9saWIvaW5kZXguZXNtLmpzXCJcbiAgfVxufSJ9).